### PR TITLE
Add farm mode Google Maps modal to dashboard

### DIFF
--- a/resources/js/pages/Granja.vue
+++ b/resources/js/pages/Granja.vue
@@ -17,7 +17,7 @@ const gameMode = ref<'explore' | 'plant'>('explore');
 let scene: THREE.Scene;
 let camera: THREE.PerspectiveCamera;
 let renderer: THREE.WebGLRenderer;
-let terrainTiles: THREE.Mesh[] = []; // Array de cuadros del terreno
+const terrainTiles: THREE.Mesh[] = []; // Array de cuadros del terreno
 let raycaster: THREE.Raycaster;
 let mouse: THREE.Vector2;
 let textureLoader: THREE.TextureLoader;

--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -4,6 +4,7 @@ import { AppPageProps } from '@/types/index';
 declare module 'vite/client' {
     interface ImportMetaEnv {
         readonly VITE_APP_NAME: string;
+        readonly VITE_GOOGLE_MAPS_API_KEY?: string;
         [key: string]: string | boolean | undefined;
     }
 
@@ -22,5 +23,11 @@ declare module 'vue' {
         $inertia: typeof Router;
         $page: Page;
         $headManager: ReturnType<typeof createHeadManager>;
+    }
+}
+
+declare global {
+    interface Window {
+        google: any;
     }
 }


### PR DESCRIPTION
## Summary
- add an interactive Google Maps modal that opens from the Farm Mode call-to-action
- dynamically load the Google Maps API, draw a sample parcel polygon, and provide usage guidance
- update shared typings and minor farm scene code quality adjustments

## Testing
- npm run lint *(fails: existing issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e1846492c0832193fc84fb40eab0e6