### PR TITLE
Add sustainable farm simulator gameplay

### DIFF
--- a/resources/js/components/LandAreaSelector.vue
+++ b/resources/js/components/LandAreaSelector.vue
@@ -101,7 +101,6 @@
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { nextTick, onMounted, reactive, ref } from 'vue';
-// @ts-ignore
 import 'leaflet-geometryutil';
 
 // Fix para los iconos de Leaflet

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { login, register } from '@/routes';
-import { Head, Link } from '@inertiajs/vue3';
+import { Head } from '@inertiajs/vue3';
 import { ref } from 'vue';
 import { Form } from '@inertiajs/vue3';
 import RegisteredUserController from '@/actions/App/Http/Controllers/Auth/RegisteredUserController';

--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -31,3 +31,5 @@ declare global {
         google: any;
     }
 }
+
+declare module 'leaflet-geometryutil';


### PR DESCRIPTION
## Summary
- replace the Three.js prototype on the farm page with a Vue-driven sustainable farming simulator featuring seasonal effects, irrigation levels, plagues, missions, and rewards
- add a module declaration for `leaflet-geometryutil` to remove the need for ts-ignore comments
- clean up unused imports in the welcome page to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e18fcc26b4832188f4234b966d49fc